### PR TITLE
Formatter from_string now accepts multiple whitespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,6 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+env
 /local_files/
 local_files/

--- a/postcodes_uk/main/exceptions.py
+++ b/postcodes_uk/main/exceptions.py
@@ -16,3 +16,8 @@ class InvalidSector(Exception):
 class InvalidUnit(Exception):
     def __init__(self, msg='Invalid postcode unit', *args, **kwargs):
         super().__init__(msg, *args, **kwargs)
+
+
+class InvalidPostcode(Exception):
+    def __init__(self, msg='Invalid postcode', *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)

--- a/postcodes_uk/main/formatter.py
+++ b/postcodes_uk/main/formatter.py
@@ -55,10 +55,13 @@ class Postcode:
             postcode
         )
 
-        area = match.group("area")
-        district = match.group("district")
-        sector = int(match.group("sector"))
-        unit = match.group("unit")
+        try:
+            area = match.group("area")
+            district = match.group("district")
+            sector = int(match.group("sector"))
+            unit = match.group("unit")
+        except:
+            raise InvalidPostcode
 
         return Postcode(area, district, sector, unit)
 

--- a/postcodes_uk/main/formatter.py
+++ b/postcodes_uk/main/formatter.py
@@ -45,13 +45,13 @@ class Postcode:
         """
 
         match = re.search(
-            "^(("
+            "^ *?(("
             "(?P<area>[A-Z]{1,2})"
             "(?P<district>[0-9][A-Z0-9]?|ASCN|STHL|TDCU|BBND|[BFS]IQQ|PCRN|TKCA))"
-            " ?"
+            " *?"
             "(?P<sector>[0-9])"
             "(?P<unit>[A-Z]{2}|BFPO ?[0-9]{1,4}|(KY[0-9]|MSR|VG|AI)[ -]?[0-9]{4}|[A-Z]{2} ?[0-9]{2}|GE ?CX|GIR ?0A{2}|SAN ?TA1"
-            "))$",
+            ")) *?$",
             postcode
         )
 

--- a/postcodes_uk/tests/test_formatter.py
+++ b/postcodes_uk/tests/test_formatter.py
@@ -7,6 +7,9 @@ from postcodes_uk.main.exceptions import *
 def test_postcode_from_string():
     assert Postcode(area="EC", district="1A", sector=1, unit="BB") == Postcode.from_string("EC1A 1BB")
     assert Postcode(area="EC", district="1A", sector=1, unit="BB") != Postcode.from_string("EC1B 1BB")
+    assert Postcode(area="EC", district="1A", sector=1, unit="BB") != Postcode.from_string("EC1B  1BB")
+    assert Postcode(area="EC", district="1A", sector=1, unit="BB") != Postcode.from_string(" EC1B 1BB")
+    assert Postcode(area="EC", district="1A", sector=1, unit="BB") != Postcode.from_string("EC1B 1BB ")
 
 
 def test_postcode_init():

--- a/postcodes_uk/tests/test_formatter.py
+++ b/postcodes_uk/tests/test_formatter.py
@@ -11,6 +11,9 @@ def test_postcode_from_string():
     assert Postcode(area="EC", district="1A", sector=1, unit="BB") != Postcode.from_string(" EC1B 1BB")
     assert Postcode(area="EC", district="1A", sector=1, unit="BB") != Postcode.from_string("EC1B 1BB ")
 
+    with pytest.raises(InvalidPostcode):
+        Postcode.from_string("1234ABCD")
+
 
 def test_postcode_init():
 


### PR DESCRIPTION
I've made a little addition to the from_string regex to accept blanks since we've seen people tend to write them